### PR TITLE
[SECCOMP-34591] Upgrade quay.io/sysdig/sysdig-stig-mini-ubi9 to 1.2.6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ EXPOSE     9187
 USER       59000:59000
 ENTRYPOINT [ "/bin/postgres_exporter" ]
 
-FROM quay.io/sysdig/sysdig-stig-mini-ubi9:1.2.3 AS ubi
+FROM quay.io/sysdig/sysdig-stig-mini-ubi9:1.2.6 AS ubi
 COPY --from=builder /bin/postgres_exporter /bin/postgres_exporter
 EXPOSE     9187
 USER       59000:59000


### PR DESCRIPTION
https://sysdig.atlassian.net/browse/SECCOMP-34591